### PR TITLE
new next page selector functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Returns a stream that fetches the given source and emits the parsed and selected
   - limitParam - Required `String`
   - startPage - Optional `Number`, defaults to 0
   - limit - Required `Number`
+  - nextPageSelector - Optional `String`
+    - If needed, you may provide multiple selectors as an array (`nextPageSelector: [ 'a.*', 'b.*' ]`)
+    - If provided, all other pagination options will only be applied on page 1 and the selector will be used to pluck the next page URL going forward
 - setup - Optional `Function` or `String`
   - Asynchronous function, runs once before the request starts for each source. Receives `source` and `meta` as arguments.
     - First argument is the source object being set up.

--- a/dist/fetch/fetchWithParser.js
+++ b/dist/fetch/fetchWithParser.js
@@ -48,12 +48,14 @@ var _default = ({
     cb(null, row);
   };
 
-  const out = (0, _readableStream.pipeline)(req, parser(), (0, _through.default)({
+  const parse = parser();
+  const out = (0, _readableStream.pipeline)(req, parse, (0, _through.default)({
     objectMode: true
   }, map), err => {
     if (err) out.emit('error', err);
-  }); // forward some props
+  }); // forward some props and events
 
+  parse.once('nextPage', (...a) => out.emit('nextPage', ...a));
   out.req = req.req;
   out.url = req.url;
 

--- a/dist/parse/formats.js
+++ b/dist/parse/formats.js
@@ -145,7 +145,7 @@ exports.xml = xml;
 const html = opt => {
   if (opt.zip) return (0, _unzip.default)(html.bind(void 0, _objectSpread(_objectSpread({}, opt), {}, {
     zip: undefined
-  })), /\.xml$/);
+  })), /\.html$/);
   return _pumpify.default.obj((0, _xml2json.default)(_objectSpread(_objectSpread({}, opt), {}, {
     strict: false
   })), json(opt));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vandelay",
-  "version": "8.0.4",
+  "version": "8.1.0",
   "description": "Imports, exports, and ETL",
   "main": "dist/index.js",
   "keywords": [

--- a/src/fetch/fetchWithParser.js
+++ b/src/fetch/fetchWithParser.js
@@ -32,16 +32,18 @@ export default ({ url, parser, source }, opt) => {
     cb(null, row)
   }
 
+  const parse = parser()
   const out = pipeline(
     req,
-    parser(),
+    parse,
     through2({ objectMode: true }, map),
     (err) => {
       if (err) out.emit('error', err)
     }
   )
 
-  // forward some props
+  // forward some props and events
+  parse.once('nextPage', (...a) => out.emit('nextPage', ...a))
   out.req = req.req
   out.url = req.url
   out.abort = () => {

--- a/src/parse/formats.js
+++ b/src/parse/formats.js
@@ -81,7 +81,7 @@ export const xml = (opt) => {
 }
 
 export const html = (opt) => {
-  if (opt.zip) return unzip(html.bind(this, { ...opt, zip: undefined }), /\.xml$/)
+  if (opt.zip) return unzip(html.bind(this, { ...opt, zip: undefined }), /\.html$/)
   return pumpify.obj(xml2json({ ...opt, strict: false }), json(opt))
 }
 


### PR DESCRIPTION
Adds a new `nextPageSelector` option to the pagination object which allows you to pull the next page out of the response body. The way it was designed it should support any parser that supports the selector option. Also refactored a ton of code.

![Screen Shot 2020-10-05 at 12 29 06 PM](https://user-images.githubusercontent.com/425716/95127494-ea7d1500-070c-11eb-8548-02ca5ed14319.png)
